### PR TITLE
Handle DELETE errors according to spec

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -753,13 +753,21 @@ class CollectionViewBase:
                 http DELETE http://localhost:6543/people/1
         '''
         DBSession = self.get_dbsession()
-        item = DBSession.query(
-            self.model
-        ).options(
-            load_only(self.key_column.name)
-        ).get(
-            self.request.matchdict['id']
-        )
+        try:
+            item = DBSession.query(
+                self.model
+            ).options(
+                load_only(self.key_column.name)
+            ).get(
+                self.request.matchdict['id']
+            )
+        except sqlalchemy.exc.DataError:
+            raise HTTPNotFound(
+                'Cannot DELETE a non existent resource ({}/{})'.format(
+                    self.collection_name, self.request.matchdict['id']
+                )
+            )
+
         if item:
             for callback in self.callbacks['before_delete']:
                 callback(self, item)
@@ -774,7 +782,11 @@ class CollectionViewBase:
                 )
             }
         else:
-            return {'data': None}
+            raise HTTPNotFound(
+                'Cannot DELETE a non existent resource ({}/{})'.format(
+                    self.collection_name, self.request.matchdict['id']
+                )
+            )
 
     @jsonapi_view
     def collection_get(self):

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -2077,6 +2077,16 @@ class TestSpec(DBTestBase):
         # Check that comments/5 no longer exists.
         self.test_app.get('/comments/5', status=404)
 
+    def test_spec_delete_no_such_item(self):
+        '''Should fail to delete non-existent comments/99999
+
+        A server SHOULD return a 404 Not Found status code if
+        a deletion request fails due to the resource not existing.
+        '''
+
+        # Delete comments/99999.
+        self.test_app.delete('/comments/99999', status=404)
+
     def test_spec_delete_relationships_onetomany(self):
         '''Should remove a comment from a post.
 


### PR DESCRIPTION
Currently, DELETE against a non-existent resource returns 200. The specification says:

> A server SHOULD return a 404 Not Found status code if a deletion request fails due to the resource not existing.

Update code to match this spec. Given that this is a `SHOULD` there may be a reason you are returning 200 I'm missing, so happy to stand corrected!

An additional failure case is where sqlalchemy raises a `DataError` exception, caused by the requested id failing to match the DB schema (e.g. requesting `cat` when the id column is type `int`).

I've opted to also return `404` here, rather than `400 Bad Request` as it is technically true, and it feels safer than trying to pass the sqlalchemy exception message to the client (and potentially reveal more about the underlying DB than might be desired). Happy to discuss this though if you think otherwise!

