### PR TITLE
Fixes #56 (post fails with primary key not called 'id')

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -1026,7 +1026,7 @@ class CollectionViewBase:
         except KeyError:
             atts = {}
         if 'id' in data:
-            atts['id'] = data['id']
+            atts[self.model.__pyramid_jsonapi__['id_col_name']] = data['id']
         item = self.model(**atts)
         mapper = sqlalchemy.inspect(self.model).mapper
         with db_session.no_autoflush:

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -2557,6 +2557,26 @@ class TestBugs(DBTestBase):
         ).json['data']
         self.assertIsInstance(data['id'], str)
 
+    def test_56_post_with_non_id_primary_key(self):
+        '''POST to model with non 'id' primary key should work.
+
+        #56: POSTing a new item where the primary key column is not 'id' causes
+        an error.
+        '''
+        data = self.test_app().post_json(
+            '/comments',
+            {
+                'data': {
+                    'id': '1000',
+                    'type': 'comments',
+                    'attributes': {
+                        'content': 'test'
+                    }
+                }
+            },
+            headers={'Content-Type': 'application/vnd.api+json'}
+        ).json['data']
+        self.assertEqual(data['id'],'1000')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Look up `id_col_name`.
- Also add test