### PR TITLE
setup.py versioning improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+version.py export-subst

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   author = 'Colin Higgs',
   author_email = 'colin.higgs70@gmail.com',
   url = 'https://github.com/colinhiggs/pyramid-jsonapi',
-  keywords = ['json', 'api', 'API', 'JSON-API', 'pyramid', 'sqlalchemy'],
+  keywords = ['json', 'api', 'json-api', 'jsonapi', 'pyramid', 'sqlalchemy'],
   classifiers = [],
   package_data={'': ['schema/*.json']}
   )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+from version import get_version
 
 requires = [
     'alchemyjsonschema',
@@ -10,9 +11,8 @@ requires = [
 setup(
   name = 'pyramid_jsonapi',
   packages = ['pyramid_jsonapi'],
-  setup_requires=['setuptools_scm'],
   install_requires=requires,
-  use_scm_version=True,
+  version=get_version(),
   description = 'Auto-build JSON API from sqlalchemy models using the pyramid framework',
   author = 'Colin Higgs',
   author_email = 'colin.higgs70@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requires = [
 
 setup(
   name = 'pyramid_jsonapi',
-  packages = ['pyramid_jsonapi'],
+  packages = find_packages(),
   install_requires=requires,
   version=get_version(),
   description = 'Auto-build JSON API from sqlalchemy models using the pyramid framework',

--- a/version.py
+++ b/version.py
@@ -1,0 +1,45 @@
+# Source: https://github.com/Changaco/version.py
+
+from os.path import dirname, isdir, join
+import re
+from subprocess import CalledProcessError, check_output
+
+
+PREFIX = ''
+
+tag_re = re.compile(r'\btag: %s([0-9][^,]*)\b' % PREFIX)
+version_re = re.compile('^Version: (.+)$', re.M)
+
+
+def get_version():
+    # Return the version if it has been injected into the file by git-archive
+    version = tag_re.search('$Format:%D$')
+    if version:
+        return version.group(1)
+
+    d = dirname(__file__)
+
+    if isdir(join(d, '.git')):
+        # Get the version using "git describe".
+        cmd = 'git describe --tags --match %s[0-9]* --dirty' % PREFIX
+        try:
+            version = check_output(cmd.split()).decode().strip()[len(PREFIX):]
+        except CalledProcessError:
+            raise RuntimeError('Unable to get version number from git tags')
+
+        # PEP 440 compatibility
+        if '-' in version:
+            if version.endswith('-dirty'):
+                raise RuntimeError('The working tree is dirty')
+            version = '.post'.join(version.split('-')[:2])
+
+    else:
+        # Extract the version from the PKG-INFO file.
+        with open(join(d, 'PKG-INFO')) as f:
+            version = version_re.search(f.read()).group(1)
+
+    return version
+
+
+if __name__ == '__main__':
+    print(get_version())


### PR DESCRIPTION
Drop setuptools_scm and switch to the simpler [version.py](https://github.com/Changaco/version.py)

This also allows versioning to be extracted from git archives, so that packages can require any tagged release from github, irrespective of pypi support, .i.e.:

```
dependency_links = [
    'https://github.com/colinhiggs/pyramid-jsonapi/archive/1.0.3.post20.zip#egg=pyramid-jsonapi-1.0.3.post20',
]

requires = [
    'pyramid_jsonapi == jsonapi-1.0.3.post20',
]
setup(
...
dependency_links=dependency_links,
install_requires=requires,
....
)
```
