### PR TITLE
Handle bad ids in GET/DELETE.

### DIFF
--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -183,6 +183,28 @@ class TestSpec(DBTestBase):
         self.assertIn('errors', r.json)
         self.assertIsInstance(r.json['errors'], list)
 
+    def test_spec_get_no_such_item(self):
+        '''Should fail to get non-existent comments/99999
+
+        A server MUST respond with 404 Not Found when processing a request
+        to fetch a single resource that does not exist
+
+        '''
+
+        # Get comments/99999
+        self.test_app().get('/comments/99999', status=404)
+
+    def test_spec_get_invalid_item(self):
+        '''Should fail to get invalid item comments/cat
+
+        A server MUST respond with 404 Not Found when processing a request
+        to fetch a single resource that does not exist
+
+        '''
+
+        # Get comments/cat
+        self.test_app().get('/comments/cat', status=404)
+
     def test_spec_get_primary_data_empty(self):
         '''Should return an empty list of results.
 


### PR DESCRIPTION
db queries can also raise `ValueError`, e.g. if an `int` id is passed when the db expects `uuid`.

Handle this as well as `DataError`, and also add some tests to cover possible mistakes (note, there is no test to trigger ValueError, since I'm not sure how to trigger thsi with a test db that uses int ids).

It also looks like the code could be DRYer - `get` and `delete` methods use similar but different ways to query the DB, that could be reconciled.