### PR TITLE
Configuration settings moved to their own class

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,6 @@
+[TYPECHECK]
+ignored-classes=pyramid_jsonapi.settings.Settings
+
+[MESSAGES CONTROL]
+disable=line-too-long
+

--- a/pyramid_jsonapi/endpoints.py
+++ b/pyramid_jsonapi/endpoints.py
@@ -1,5 +1,4 @@
 """Classes to store and manipulate endpoints and routes."""
-from pyramid.settings import asbool
 
 
 class RoutePatternConstructor():
@@ -60,40 +59,21 @@ class EndpointData():
     """Class to hold endpoint data and utility methods.
 
     Arguments:
-        config: A pyramid Configurator object.
+        api: A PyramidJSONAPI object.
 
     """
 
-    def __init__(self, config):
-        self.config = config
-        settings = self.config.registry.settings
-        self.route_name_prefix = settings.get(
-            'pyramid_jsonapi.route_name_prefix', 'pyramid_jsonapi'
-        )
-
-        self.route_pattern_prefix = settings.get(
-            'pyramid_jsonapi.route_pattern_prefix', ''
-        )
-
-        self.route_name_sep = settings.get(
-            'pyramid_jsonapi.route_name_sep', ':'
-        )
-
-        self.route_pattern_sep = settings.get(
-            'pyramid_jsonapi.route_pattern_sep', '/'
-        )
-
-        self.api_prefix = settings.get(
-            'pyramid_jsonapi.route_pattern_api_prefix',
-            asbool(settings.get(
-                'pyramid_jsonapi.metadata_endpoints', 'true'
-            )) and 'api' or ''
-        )
-
-        self.metadata_prefix = settings.get(
-            'pyramid_jsonapi.route_pattern_metadata_prefix', 'metadata'
-        )
-
+    def __init__(self, api):
+        self.config = api.config
+        settings = api.settings
+        self.route_name_prefix = settings.route_name_prefix
+        self.route_pattern_prefix = settings.route_pattern_prefix
+        self.route_name_sep = settings.route_name_sep
+        self.route_pattern_sep = settings.route_pattern_sep
+        self.api_prefix = ''
+        if settings.metadata_endpoints:
+            self.api_prefix = settings.route_pattern_api_prefix
+        self.metadata_prefix = settings.route_pattern_metadata_prefix
         self.rp_constructor = RoutePatternConstructor(
             sep=self.route_pattern_sep,
             main_prefix=self.route_pattern_prefix,

--- a/pyramid_jsonapi/metadata/JSONSchema.py
+++ b/pyramid_jsonapi/metadata/JSONSchema.py
@@ -61,10 +61,7 @@ class JSONSchema():
         Reads 'pyramid_jsonapi.schema_file' from config,
         or defaults to one provided with the package.
         """
-        schema_file = self.api.config.registry.settings.get(
-            'pyramid_jsonapi.schema_file'
-        )
-
+        schema_file = self.api.settings.schema_file
         if schema_file:
             with open(schema_file) as schema_f:
                 schema = schema_f.read()

--- a/pyramid_jsonapi/metadata/__init__.py
+++ b/pyramid_jsonapi/metadata/__init__.py
@@ -10,8 +10,6 @@ import importlib
 import os.path
 import pkgutil
 
-from pyramid.settings import aslist
-
 
 class MetaData():
     """Adds routes and views for all metadata modules.
@@ -32,19 +30,10 @@ class MetaData():
         self.api = api
         # aslist expects space-separated strings to convert to lists.
         # iter_modules returns a list of tuples - we only want name ([1])
-        self.modules = aslist(
-            self.api.config.registry.settings.get(
-                'pyramid_jsonapi.metadata_modules',
-                ' '.join(
-                    [
-                        x[1] for x in pkgutil.iter_modules(
-                            [os.path.dirname(__file__)]
-                        )
-                    ]
-                )
-            ),
-            flatten=True
-        )
+        self.modules = self.api.settings.metadata_modules.aslist()
+        if not self.modules:
+            self.modules = [x[1] for x in pkgutil.iter_modules([os.path.dirname(__file__)])]
+
         self.make_routes_views()
 
     def make_routes_views(self):

--- a/pyramid_jsonapi/settings.py
+++ b/pyramid_jsonapi/settings.py
@@ -1,0 +1,67 @@
+"""pyramid_jsonapi configuration settings."""
+
+import logging
+from pyramid.settings import asbool, aslist
+
+
+class ConfigString(str):
+    """Override 'str' to add custom methods."""
+    def asbool(self):
+        """Access pyramid.settings.asbool in a pythonic way."""
+        return asbool(self)
+
+    def aslist(self):
+        """Access pyramid.settings.aslist in a pythonic way."""
+        return aslist(self, flatten=True)
+
+    __bool__ = asbool
+
+
+class Settings():
+    """Class to store pyramid configuration settings (from the ini file)
+    and provide easier programatic access to them."""
+
+    # Default configuration values
+    _defaults = {
+        'allow_client_ids': {'val': False, 'desc': 'Allow client to specify resource ids.'},
+        'filter_operator_groups': {'val': '', 'desc': ''},
+        'metadata_endpoints': {'val': True, 'desc': 'Should /metadata endpoint be enabled?'},
+        'metadata_modules': {'val': '', 'desc': 'Modules to load to provide metadata endpoints (defaults to all modules in the metadata package).'},
+        'paging_default_limit': {'val': 10, 'desc': 'Default pagination limit for collections.'},
+        'paging_max_limit': {'val': 100, 'desc': 'Default limit on the number of items returned for collections.'},
+        'route_name_prefix': {'val': 'pyramid_jsonapi', 'desc': 'Prefix for pyramid route names for view_classes.'},
+        'route_pattern_api_prefix': {'val': 'api', 'desc': 'Prefix for api endpoints (if metadata_endpoints is enabled).'},
+        'route_pattern_metadata_prefix': {'val': 'metadata', 'desc': 'Prefix for metadata endpoints (if metadata_endpoints is enabled).'},
+        'route_pattern_prefix': {'val': '', 'desc': '"Parent" prefix for all endpoints'},
+        'route_name_sep': {'val': ':', 'desc': 'Separator for pyramid route names.'},
+        'route_pattern_sep': {'val': '/', 'desc': 'Separator for pyramid route patterns.'},
+        'schema_file': {'val': '', 'desc': 'File containing jsonschema JSON for validation.'},
+        'schema_validation': {'val': True, 'desc': 'jsonschema schema validation enabled?'},
+        'tests_models_iterable': {'val': '', 'desc': ''},
+        'debug_endpoints': {'val': False, 'desc': ''},
+        'debug_test_data_module': {'val': 'test_data', 'desc': ''},
+        'debug_meta': {'val': False, 'desc': ''},
+    }
+
+    def __init__(self, settings):
+        """
+        Create attributes from settings, overriding defaults
+        with values from pyramid config.
+
+        Arguments:
+            settings: Pyramid config.registry.settings dictionary.
+
+        """
+        prefix = 'pyramid_jsonapi.'
+        # Extract pyramid_jsonapi config from settings, stripping prefix
+        pj_settings = {k[len(prefix):]: v for k, v in settings.items() if k.startswith(prefix)}
+
+        # Create attributes from  _defaults, overriding with pj_settings
+        for key, opts in self._defaults.items():
+            val = opts['val']
+            if key in pj_settings:
+                val = pj_settings.pop(key)
+            setattr(self, key, ConfigString(val))
+
+        # Remaining keys must have ben invalid config options
+        logging.warning("Invalid configuration options: %s", pj_settings)

--- a/test_project/development.ini
+++ b/test_project/development.ini
@@ -17,14 +17,14 @@ pyramid.includes =
 
 sqlalchemy.url = postgresql://test:test@localhost/test
 
-pyramid_jsonapi.debug.meta = false
-pyramid_jsonapi.debug.debug_endpoints = true
-pyramid_jsonapi.debug.test_data_module = test_project.test_data
+pyramid_jsonapi.debug_meta = false
+pyramid_jsonapi.debug_endpoints = true
+pyramid_jsonapi.debug_test_data_module = test_project.test_data
 
 pyramid_jsonapi.route_name_prefix = pyramid_jsonapi
 pyramid_jsonapi.route_pattern_prefix = 
-pyramid_jsonapi.paging.default_limit = 10
-pyramid_jsonapi.paging.max_limit = 100
+pyramid_jsonapi.paging_default_limit = 10
+pyramid_jsonapi.paging_max_limit = 100
 pyramid_jsonapi.allow_client_ids = true
 
 

--- a/test_project/test_project/__init__.py
+++ b/test_project/test_project/__init__.py
@@ -87,7 +87,7 @@ def main(global_config, **settings):
     pj = pyramid_jsonapi.PyramidJSONAPI(
         config,
         test_settings['models_iterable'][
-            settings.get('pyramid_jsonapi.tests.models_iterable', 'module')
+            settings.get('pyramid_jsonapi.tests_models_iterable', 'module')
         ],
         lambda view: models.DBSession
     )

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -71,8 +71,8 @@ class DBTestBase(unittest.TestCase):
             return self._test_app
         return self.new_test_app(options)
 
-    @classmethod
-    def new_test_app(cls, options=None):
+    @staticmethod
+    def new_test_app(options=None):
         '''Create a test app.'''
         config_path = '{}/testing.ini'.format(parent_dir)
         if options:

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -2455,7 +2455,7 @@ class TestErrors(DBTestBase):
             Exception,
             r'^Model \S+ has more than one primary key.$',
             self.test_app,
-            {'pyramid_jsonapi.tests.models_iterable': 'composite_key'}
+            {'pyramid_jsonapi.tests_models_iterable': 'composite_key'}
         )
 
 
@@ -2620,7 +2620,7 @@ class TestFeatures(DBTestBase):
     def test_feature_construct_with_models_list(self):
         '''Should construct an api from a list of models.'''
         test_app = self.test_app(
-            options={'pyramid_jsonapi.tests.models_iterable': 'list'}
+            options={'pyramid_jsonapi.tests_models_iterable': 'list'}
         )
         test_app.get('/people/1')
 
@@ -2628,8 +2628,8 @@ class TestFeatures(DBTestBase):
         '''Should create a set of debug endpoints for manipulating the database.'''
         test_app = self.test_app(
             options={
-                'pyramid_jsonapi.debug.debug_endpoints': 'true',
-                'pyramid_jsonapi.debug.test_data_module': 'test_project.test_data'
+                'pyramid_jsonapi.debug_endpoints': 'true',
+                'pyramid_jsonapi.debug_test_data_module': 'test_project.test_data'
             }
         )
         test_app.get('/debug/populate')
@@ -2680,7 +2680,7 @@ class TestFeatures(DBTestBase):
     def test_feature_debug_meta(self):
         '''Should add meta information.'''
         test_app = self.test_app(
-            options={'pyramid_jsonapi.debug.meta': 'true'}
+            options={'pyramid_jsonapi.debug_meta': 'true'}
         )
         self.assertIn('debug',test_app.get('/people/1').json['meta'])
 

--- a/test_project/testing.ini
+++ b/test_project/testing.ini
@@ -10,7 +10,7 @@ pyramid_jsonapi.allow_client_ids = true
 pyramid_jsonapi.filter_operator_groups =
   standard
   json
-pyramid_jsonapi.tests.models_iterable = module
+pyramid_jsonapi.tests_models_iterable = module
 pyramid_jsonapi.route_pattern_api_prefix = 
 
 pyramid.reload_templates = true


### PR DESCRIPTION
* New `pyramid_jsonapi.settings` module/class
* Stores default config values and descriptions
* Config available as class attributes
* attributes are of type `ConfString` - a class which maps `pyramid.settings` `asbool` and `aslist` rto be methods on the object.
* Pyramid config (inifile) overrides pyramid_jsonapi defaults - updated by key - preventing setting of unknown values in the config.