### PR TITLE
Move version.py into project.

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -51,6 +51,9 @@ import pyramid_jsonapi.endpoints
 import pyramid_jsonapi.jsonapi
 import pyramid_jsonapi.metadata
 import pyramid_jsonapi.settings
+import pyramid_jsonapi.version
+
+__version__ = pyramid_jsonapi.version.get_version()
 
 ONETOMANY = sqlalchemy.orm.interfaces.ONETOMANY
 MANYTOMANY = sqlalchemy.orm.interfaces.MANYTOMANY

--- a/pyramid_jsonapi/version.py
+++ b/pyramid_jsonapi/version.py
@@ -20,7 +20,7 @@ def get_version():
 
     d = dirname(__file__)
 
-    if isdir(join(d, '.git')):
+    if isdir(join(d, '../.git')):
         # Get the version using "git describe".
         cmd = 'git describe --tags --match %s[0-9]* --dirty' % PREFIX
         try:
@@ -30,13 +30,11 @@ def get_version():
 
         # PEP 440 compatibility
         if '-' in version:
-            if version.endswith('-dirty'):
-                raise RuntimeError('The working tree is dirty')
             version = '.post'.join(version.split('-')[:2])
 
     else:
         # Extract the version from the PKG-INFO file.
-        with open(join(d, 'PKG-INFO')) as f:
+        with open(join(d, '../PKG-INFO')) as f:
             version = version_re.search(f.read()).group(1)
 
     return version

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
+import sys
 from setuptools import setup, find_packages
+# Append project to sys.path so that we can import version 'directly'.
+# Importing as 'from pyramid_jsonapi import version' needs the deps we
+# haven't installed yet!
+sys.path.append("pyramid_jsonapi")
 from version import get_version
 
 requires = [


### PR DESCRIPTION
This allows us to have `pyramid_jsonapi.__version__` while still using `version.py` in setup.py etc.