### PR TITLE
Check view responses are valid by schema, and 'hide' unexpected ones from the client.

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -744,7 +744,8 @@ class CollectionViewBase:
             jsonapi.Document: Resource Identifier for deleted object.
 
         Raises:
-            HTTPFailedDependency: if collection/id does not exist
+            HTTPFailedDependency: if a database constraint would be broken by
+            deleting the specified resource from the relationship.
 
         Example:
             delete person 1:

--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -414,7 +414,7 @@ class CollectionViewBase:
                             self.request.current_route_path()
                         )
                         if hasattr(exc, 'code'):
-                            if exc.code.startswith('4'):  # pylint:disable=no-member
+                            if 400 <= exc.code < 500:  # pylint:disable=no-member
                                 raise HTTPBadRequest("Unexpected client error: {}".format(exc))
                         else:
                             raise HTTPInternalServerError("Unexpected server error.")

--- a/pyramid_jsonapi/endpoints.py
+++ b/pyramid_jsonapi/endpoints.py
@@ -1,5 +1,18 @@
 """Classes to store and manipulate endpoints and routes."""
 
+from pyramid.httpexceptions import (
+    HTTPBadRequest,
+    HTTPCreated,
+    HTTPConflict,
+    HTTPFailedDependency,
+    HTTPForbidden,
+    HTTPInternalServerError,
+    HTTPNotAcceptable,
+    HTTPNotFound,
+    HTTPOk,
+    HTTPUnsupportedMediaType,
+)
+
 
 class RoutePatternConstructor():
     """Construct pyramid_jsonapi route patterns."""
@@ -83,57 +96,139 @@ class EndpointData():
 
         # Mapping of endpoints, http_methods and options for constructing routes and views.
         # Update this dictionary prior to calling create_jsonapi()
+        # 'responses' can be 'global', 'per-endpoint' and 'per-endpoint-method'
         # Mandatory 'endpoint' keys: http_methods
         # Optional 'endpoint' keys: route_pattern_suffix
         # Mandatory 'http_method' keys: function
         # Optional 'http_method' keys: renderer
         self.endpoints = {
-            'collection': {
-                'http_methods': {
-                    'GET': {
-                        'function': 'collection_get',
+            'responses': {
+                # Top-level: apply to all endpoints
+                HTTPUnsupportedMediaType: {'reason': ['Servers MUST respond with a 415 Unsupported Media Type status code if a request specifies the header Content-Type: application/vnd.api+json with any media type parameters.']},
+                HTTPNotAcceptable: {'reason': ['Servers MUST respond with a 406 Not Acceptable status code if a request’s Accept header contains the JSON API media type and all instances of that media type are modified with media type parameters.']},
+                HTTPBadRequest: {'reason': ['If a server encounters a query parameter that does not follow the naming conventions above, and the server does not know how to process it as a query parameter from this specification, it MUST return 400 Bad Request.',
+                                            'If the server does not support sorting as specified in the query parameter sort, it MUST return 400 Bad Request.',
+                                            'If an endpoint does not support the include parameter, it MUST respond with 400 Bad Request to any requests that include it.',
+                                            'If the request content is malformed in some way.']},
+            },
+            'endpoints': {
+                'collection': {
+                    'responses': {
+                        HTTPInternalServerError: {'reason': ['An error occurred on the server.']}
                     },
-                    'POST': {
-                        'function': 'collection_post',
+                    'http_methods': {
+                        'GET': {
+                            'function': 'collection_get',
+                            'responses': {
+                                HTTPOk: {'reason': ['A server MUST respond to a successful request to fetch an individual resource or resource collection with a 200 OK response.']},
+                            },
+                        },
+                        'POST': {
+                            'function': 'collection_post',
+                            'responses': {
+                                HTTPCreated: {'reason': ['If a POST request did not include a Client-Generated ID and the requested resource has been created successfully, the server MUST return a 201 Created status code.']},
+                                HTTPForbidden: {'reason': ['A server MUST return 403 Forbidden in response to an unsupported request to create a resource with a client-generated ID.',
+                                                           'A server MAY return 403 Forbidden in response to an unsupported request to create a resource.']},
+                                HTTPNotFound: {'reason': ['A server MUST return 404 Not Found when processing a request to modify a resource that does not exist.',
+                                                          'A server MUST return 404 Not Found when processing a request that references a related resource that does not exist.']},
+                                HTTPConflict: {'reason': ['A server MUST return 409 Conflict when processing a POST request to create a resource with a client-generated ID that already exists.',
+                                                          'A server MUST return 409 Conflict when processing a POST request in which the resource object’s type is not among the type(s) that constitute the collection represented by the endpoint.']},
+                                HTTPBadRequest: {'reason': ['Request is malformed in some way.']},
+                            },
+                        },
                     },
                 },
-            },
-            'item': {
-                'route_pattern_suffix': '{id}',
-                'http_methods': {
-                    'DELETE': {
-                        'function': 'delete',
+                'item': {
+                    'responses': {
+                        HTTPOk: {'reason': ['A server MUST respond to a successful request to fetch an individual resource or resource collection with a 200 OK response.']},
                     },
-                    'GET': {
-                        'function': 'get',
-                    },
-                    'PATCH': {
-                        'function': 'patch',
+                    'route_pattern_suffix': '{id}',
+                    'http_methods': {
+                        'DELETE': {
+                            'function': 'delete',
+                            'responses': {
+                                HTTPOk: {'reason': ['A server MUST return a 200 OK status code if a deletion request is successful and the server responds with only top-level meta data.']},
+                                HTTPNotFound: {'reason': ['A server SHOULD return a 404 Not Found status code if a deletion request fails due to the resource not existing.']},
+                                HTTPFailedDependency: {'reason': ['If a database constraint would be broken by deleting the specified resource from the relationship.']},
+                            },
+                        },
+                        'GET': {
+                            'function': 'get',
+                            'responses': {
+                                HTTPOk: {'reason': ['A server MUST respond to a successful request to fetch an individual resource or resource collection with a 200 OK response.']},
+                                HTTPNotFound: {'reason': ['A server MUST respond with 404 Not Found when processing a request to fetch a single resource that does not exist.']},
+                            },
+                        },
+                        'PATCH': {
+                            'function': 'patch',
+                            'responses': {
+                                HTTPOk: {'reason': ['If an update is successful and the server doesn’t update any attributes besides those provided, the server MUST return either a 200 OK status code and response document']},
+                                HTTPForbidden: {'reason': ['A server MUST return 403 Forbidden in response to an unsupported request to update a resource or relationship.']},
+                                HTTPNotFound: {'reason': ['A server MUST return 404 Not Found when processing a request to modify a resource that does not exist.',
+                                                          'A server MUST return 404 Not Found when processing a request that references a related resource that does not exist.']},
+                                HTTPBadRequest: {'reason': ['Request is malformed in some way.']},
+                                HTTPConflict: {'reason': ['A server MAY return 409 Conflict when processing a PATCH request to update a resource if that update would violate other server-enforced constraints (such as a uniqueness constraint on a property other than id).',
+                                                          'A server MUST return 409 Conflict when processing a PATCH request in which the resource object’s type and id do not match the server’s endpoint.']},
+                            },
+                        },
                     },
                 },
-            },
-            'related': {
-                'route_pattern_suffix': '{id}/{relationship}',
-                'http_methods': {
-                    'GET': {
-                        'function': 'related_get',
+                'related': {
+                    'responses': {
+                        HTTPBadRequest: {'reason': ['If a server is unable to identify a relationship path or does not support inclusion of resources from a path, it MUST respond with 400 Bad Request.']},
+                    },
+                    'route_pattern_suffix': '{id}/{relationship}',
+                    'http_methods': {
+                        'GET': {
+                            'function': 'related_get',
+                            'responses': {
+                                HTTPOk: {'reason': ['A server MUST respond to a successful request to fetch an individual resource or resource collection with a 200 OK response.']},
+                                HTTPBadRequest: {'reason': ['A bad filter is used.']},
+                            }
+                        },
                     },
                 },
-            },
-            'relationships': {
-                'route_pattern_suffix': '{id}/relationships/{relationship}',
-                'http_methods': {
-                    'DELETE': {
-                        'function': 'relationships_delete',
+                'relationships': {
+                    'responses': {
+                        HTTPOk: {'reason': ['A server MUST respond to a successful request to fetch a relationship with a 200 OK response.']},
+                        HTTPNotFound: {'reason': ['A server MUST return 404 Not Found when processing a request to fetch a relationship link URL that does not exist.']},
                     },
-                    'GET': {
-                        'function': 'relationships_get',
-                    },
-                    'PATCH': {
-                        'function': 'relationships_patch',
-                    },
-                    'POST': {
-                        'function': 'relationships_post',
+                    'route_pattern_suffix': '{id}/relationships/{relationship}',
+                    'http_methods': {
+                        'DELETE': {
+                            'function': 'relationships_delete',
+                            'responses': {
+                                HTTPOk: {'reason': ['If all of the specified resources are able to be removed from, or are already missing from, the relationship then the server MUST return a successful response.']},
+                                HTTPConflict: {'reason'},
+                                HTTPFailedDependency: {'reason': ['If a database constraint would be broken by deleting the specified resource from the relationship.']},
+                                HTTPForbidden: {'reason': ['If the client makes a DELETE request to a URL from a relationship link the server MUST delete the specified members from the relationship or return a 403 Forbidden response.']},
+                            },
+                        },
+                        'GET': {
+                            'function': 'relationships_get',
+                            'responses': {
+                                HTTPOk: {'reason': ['A server MUST respond to a successful request to fetch a relationship with a 200 OK response.']},
+                                HTTPBadRequest: {'reason': ['If a server is unable to identify a relationship path or does not support inclusion of resources from a path, it MUST respond with 400 Bad Request.',
+                                                            'A bad filter is used.']},
+                            },
+                        },
+                        'PATCH': {
+                            'function': 'relationships_patch',
+                            'responses': {
+                                HTTPOk: {'reason': ['If a server accepts an update but also changes the targeted relationship(s) in other ways than those specified by the request, it MUST return a 200 OK response']},
+                                HTTPConflict: {'reason': ['A server MUST return 409 Conflict when processing a PATCH request in which the resource object’s type and id do not match the server’s endpoint.']},
+                                HTTPForbidden: {'reason': ['If a client makes a PATCH request to a URL from a to-many relationship link, the server MUST either completely replace every member of the relationship, return an appropriate error response if some resources can not be found or accessed, or return a 403 Forbidden response if complete replacement is not allowed by the server.',
+                                                           'A server MUST return 403 Forbidden in response to an unsupported request to update a relationship.']},
+                                HTTPFailedDependency: {'reason': ['If a database constraint would be broken by modifying the specified resource in a relationship.']},
+                            },
+                        },
+                        'POST': {
+                            'function': 'relationships_post',
+                            'responses': {
+                                HTTPConflict: {'reason': ['A server MUST return 409 Conflict when processing a POST request in which the resource object’s type is not among the type(s) that constitute the collection represented by the endpoint.']},
+                                HTTPFailedDependency: {'reason': ['If a database constraint would be broken by adding the specified resource to the relationship.']},
+                            },
+                        },
                     },
                 },
             },
@@ -159,7 +254,7 @@ class EndpointData():
             view: A view_class to associate routes and views with.
         """
 
-        for endpoint, endpoint_opts in self.endpoints.items():
+        for endpoint, endpoint_opts in self.endpoints['endpoints'].items():
             route_name = self.make_route_name(
                 view.collection_name,
                 suffix=endpoint

--- a/pyramid_jsonapi/settings.py
+++ b/pyramid_jsonapi/settings.py
@@ -64,4 +64,5 @@ class Settings():
             setattr(self, key, ConfigString(val))
 
         # Remaining keys must have ben invalid config options
-        logging.warning("Invalid configuration options: %s", pj_settings)
+        if pj_settings:
+            logging.warning("Invalid configuration options: %s", pj_settings)


### PR DESCRIPTION
Add response checking decorator to wrap view methods.
* Catch all exceptions, check if they are in the 'responses' lists
  in the endpoints data or not.
* If not, raise a generic error, and log the real one.
* Otherwise, just re-raise.