### PR TITLE
Return false on DB errors querying ids.

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -1977,11 +1977,14 @@ class CollectionViewBase:
             bool: True if object exists, False if not.
         """
         db_session = self.get_dbsession()
-        item = db_session.query(
-            self.model
-        ).options(
-            load_only(self.key_column.name)
-        ).get(obj_id)
+        try:
+            item = db_session.query(
+                self.model
+            ).options(
+                load_only(self.key_column.name)
+            ).get(obj_id)
+        except (sqlalchemy.exc.DataError, sqlalchemy.exc.StatementError):
+            item = False
         return bool(item)
 
     def column_info_from_name(self, name, model=None):


### PR DESCRIPTION
Same exception-handling as in other places where db queries using client-provided id are used.

Alternatively we could raise `HTTPBadRequest` at this point, but elsewhere we treat invalid and missing ids as equivalent, so just return `False` here.

Note - in this and other places in the code we handle `StatementError` - however there's no way to test this in the current framework unless we have something like uuids in the test DB. These bugs are ones I'm just finding by chance through using uuids in other projects. This explains the coverage drop.