### PR TITLE
Refactor route_pattern_suffix.

### DIFF
--- a/docs/source/customisation.rst
+++ b/docs/source/customisation.rst
@@ -31,10 +31,11 @@ This takes the following format:
 
   {
     'item': {
-      'route_pattern_suffix': '{id}',
+      'route_pattern': '{'fields': ['id'], 'pattern': '{{{}}}'}',
       'http_methods': {
         'DELETE': {
           'function': 'delete',
+          'responses'': { HTTPOk: {'reason': ['A server MUST return a 200 OK status code if a deletion request is successful']}},
         },
         'GET': {
           'function': 'get',
@@ -48,8 +49,10 @@ This takes the following format:
   }
 
 * There are 4 ``endpoints`` defined: ``collection``, ``item``, ``relationships`` and ``related``.
-* Each ``endpoint`` may have ``route_pattern_suffix`` defined (if ommitted, defaults to ``''``).
+* Each ``endpoint`` may have ``route_pattern`` defined. This is a list of fields, and the format string used to join them. (``{sep}`` will be replaced with ``route_name_sep``)
 * Each ``endpoint`` may have 0 or more ``http_methods`` defined. (``GET``, ``POST``, etc).
+* Each ``endpoint`` may have ``responses`` defined. This is a dictionary of ``pyramid.httpexceptions`` keys, the value is a dict with ``reason``
+  containing list of reasons for returning this response.
 * Each ``method`` must have ``function`` defined. This is the name (string) of the view function to call for this endpoint.
 * Each ``method`` may have a ``renderer`` defined (if omitted, this defaults to ``'json'``).
 

--- a/pyramid_jsonapi/endpoints.py
+++ b/pyramid_jsonapi/endpoints.py
@@ -44,7 +44,7 @@ class RoutePatternConstructor():
             new_comps.append(component)
         return self.sep.join(new_comps)
 
-    def api_pattern(self, name, rstrip=True, *components):
+    def api_pattern(self, name, *components, rstrip=True):
         """Generate a route pattern from a collection name and suffix components.
 
         Arguments:

--- a/pyramid_jsonapi/endpoints.py
+++ b/pyramid_jsonapi/endpoints.py
@@ -44,16 +44,20 @@ class RoutePatternConstructor():
             new_comps.append(component)
         return self.sep.join(new_comps)
 
-    def api_pattern(self, name, *components):
+    def api_pattern(self, name, rstrip=True, *components):
         """Generate a route pattern from a collection name and suffix components.
 
         Arguments:
             name (str): A collection name.
+            rstrip (bool): Strip trailing separator (defaults to True).
             *components (str): components to add after collection name.
         """
-        return self.pattern_from_components(
+        pattern = self.pattern_from_components(
             '', self.main_prefix, self.api_prefix, name, *components
-        ).rstrip(self.sep)
+        )
+        if rstrip:
+            pattern = pattern.rstrip(self.sep)
+        return pattern
 
     def metadata_pattern(self, metadata_type, *components):
         """Generate a metadata route pattern.


### PR DESCRIPTION
`route_pattern_suffix` in endpoints now replaced with `route_pattern` dict, containing `fields` (a list of fields in order of use in route path) and `pattern` (the python `format` string to use to join them. pattern can also contain `{sep}` which will be substituted with the route_separator (i.e. `/`)