### PR TITLE
Push sphinx badge to github gh-pages and remote-link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ The pyramid-jsonapi project
 .. image:: https://coveralls.io/repos/github/colinhiggs/pyramid-jsonapi/badge.svg?branch=master
   :target: https://coveralls.io/github/colinhiggs/pyramid-jsonapi?branch=master
 
-.. image:: pylint-badge.svg
+.. image:: https://raw.githubusercontent.com/colinhiggs/pyramid-jsonapi/gh-pages/pylint-badge.svg
 
 Create a JSON-API (`<http://jsonapi.org/>`_) standard API from a database using
 the sqlAlchemy ORM and pyramid framework.

--- a/docs/sphinx.sh
+++ b/docs/sphinx.sh
@@ -8,9 +8,9 @@ PATH=bin/:$PATH
 sphinx-apidoc -f -T -e -o docs/source/apidoc pyramid_jsonapi
 # Generate config docs from python method
 python -c 'import pyramid_jsonapi.settings as pjs; s = pjs.Settings({}); print(s.sphinx_doc())' >docs/source/apidoc/settings.inc
-travis-sphinx build
+travis-sphinx build --source=docs/source
 # Get a pylint badge
-wget https://mperlet.de/pybadge/badges/$(pylint pyramid_jsonapi |grep "rated at" |awk '{print $7}' |cut -f 1 -d '/').svg -O target/doc/build/pylint-badge.svg
+wget https://mperlet.de/pybadge/badges/$(pylint pyramid_jsonapi |grep "rated at" |awk '{print $7}' |cut -f 1 -d '/').svg -O doc/build/pylint-badge.svg
 if [[ $TRAVIS_BRANCH == "master" && -n $TRAVIS_TAG ]]; then
   travis-sphinx deploy
 fi

--- a/docs/sphinx.sh
+++ b/docs/sphinx.sh
@@ -8,9 +8,9 @@ PATH=bin/:$PATH
 sphinx-apidoc -f -T -e -o docs/source/apidoc pyramid_jsonapi
 # Generate config docs from python method
 python -c 'import pyramid_jsonapi.settings as pjs; s = pjs.Settings({}); print(s.sphinx_doc())' >docs/source/apidoc/settings.inc
-# Get a pylint badge
-wget https://mperlet.de/pybadge/badges/$(pylint pyramid_jsonapi |grep "rated at" |awk '{print $7}' |cut -f 1 -d '/').svg -O docs/source/pylint-badge.svg
 travis-sphinx build
+# Get a pylint badge
+wget https://mperlet.de/pybadge/badges/$(pylint pyramid_jsonapi |grep "rated at" |awk '{print $7}' |cut -f 1 -d '/').svg -O target/doc/build/pylint-badge.svg
 if [[ $TRAVIS_BRANCH == "master" && -n $TRAVIS_TAG ]]; then
   travis-sphinx deploy
 fi


### PR DESCRIPTION
Note: This will need a new tag issuing on a commit to master to kick off the `travis-sphinx deploy` step which will update gh-pages. (Though this is probably needed anyway to make the docs reflect the current state of the `master` branch).