### PR TITLE
Use doc.resources list, not constructed data dict, for returned count.

### DIFF
--- a/pyramid_jsonapi/collection_view.py
+++ b/pyramid_jsonapi/collection_view.py
@@ -1382,7 +1382,7 @@ class CollectionViewBase:
             res = pyramid_jsonapi.jsonapi.Resource()
             res.update(item)
             doc.resources.append(res)
-        results['returned'] = len(doc.data)
+        results['returned'] = len(doc.resources)
 
         doc.meta = {'results': results}
         return doc


### PR DESCRIPTION
TODO: Add a test that meta fields (available, returned etc) match actual db counts.