### PR TITLE
Ignore too-many-lines

### DIFF
--- a/pyramid_jsonapi/collection_view.py
+++ b/pyramid_jsonapi/collection_view.py
@@ -1,4 +1,5 @@
 """Provide base class for collection views and utilities."""
+# pylint: disable=too-many-lines; It's mostly docstrings
 import functools
 import itertools
 import logging


### PR DESCRIPTION
Just checked, and while the total length is 2261 lines, the actual code without docstrings is only 627, so it's just not an issue :smiley: 