### PR TITLE
Make metadata module loading explicit.

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -1,15 +1,22 @@
 Metadata Modules
 ================
 
-Metadata modules provide access to metadata about the API. The :class:`pyramid_jsonapi.metadata` class is responsible for loading the modules and setting up routes and views under ``/metadata`` (by default - see :mod:`pyramid_jsonapi.settings`).
+Metadata modules provide access to metadata about the API. The
+:class:`pyramid_jsonapi.metadata` class is responsible for loading the modules
+and setting up routes and views under ``/metadata``
+(by default - see :mod:`pyramid_jsonapi.settings`).
 
 Built-in Modules
 ----------------
 
-By default, all modules in the ``metadata`` directory in the project are loaded.  This can be
-overridden by changing the ``metadata_modules`` configuration option (see :mod:`pyramid_jsonapi.settings`).
+The ``metadata_modules`` configuration option lists modules which are to be loaded
+(see :mod:`pyramid_jsonapi.settings`). If this list is empty, no modules
+will be loaded.
 
-The following modules are included:
+*Note*: Some modules are required for core functionality - for example schema
+validation requires the ``jsonschema`` module.
+
+The default setting for this option includes the following modules:
 
 .. toctree::
    :glob:

--- a/docs/sphinx.sh
+++ b/docs/sphinx.sh
@@ -12,7 +12,7 @@ sphinx-apidoc -f -T -e -o ${SOURCE}/apidoc pyramid_jsonapi
 python -c 'import pyramid_jsonapi.settings as pjs; s = pjs.Settings({}); print(s.sphinx_doc())' >docs/source/apidoc/settings.inc
 travis-sphinx --outdir=${TARGET} build --source=${SOURCE}
 # Get a pylint badge
-wget https://mperlet.de/pybadge/badges/$(pylint pyramid_jsonapi |grep "rated at" |awk '{print $7}' |cut -f 1 -d '/').svg -O ${TARGET}/pylint-badge.svg
+wget --tries=3 --timeout=20 https://mperlet.github.io/pybadge/badges/$(pylint pyramid_jsonapi |grep "rated at" |awk '{print $7}' |cut -f 1 -d '/').svg -O ${TARGET}/pylint-badge.svg
 # Build docs if this is master branch, and HEAD has a tag associated with it
 if [[ $TRAVIS_BRANCH == "master" ]] && git describe --exact-match HEAD; then
   echo "Deploying docs to gh-pages..."

--- a/pyramid_jsonapi/metadata/__init__.py
+++ b/pyramid_jsonapi/metadata/__init__.py
@@ -7,18 +7,15 @@ under the 'metadata' endpoint."""
 
 import collections
 import importlib
-import os.path
-import pkgutil
 
 
 class MetaData():
     """Adds routes and views for all metadata modules.
 
-    Plugins are added by the module name being added to self.modules
-    This may be overriden in the pyramid inifile config option
-    'pyramid_jsonapi.metadata_modules'
-    Modules specified in this way should be space or newline separated
-    (see pyramid.settings aslist())
+    Metadata modules are added by inclusion in the ``metadata_modules`` option
+    in settings (see :mod:`pyramid_jsonapi.settings` for default values).
+    Modules should be space or newline separated, and must be installed such
+    that they can be imported by python.
 
     All modules MUST have a class with the same name as the package.
     This class MAY contain a 'views' attribute, which contains a list
@@ -31,9 +28,6 @@ class MetaData():
         # aslist expects space-separated strings to convert to lists.
         # iter_modules returns a list of tuples - we only want name ([1])
         self.modules = self.api.settings.metadata_modules.aslist()
-        if not self.modules:
-            self.modules = [x[1] for x in pkgutil.iter_modules([os.path.dirname(__file__)])]
-
         self.make_routes_views()
 
     def make_routes_views(self):

--- a/pyramid_jsonapi/settings.py
+++ b/pyramid_jsonapi/settings.py
@@ -32,7 +32,7 @@ class Settings():
     _defaults = {
         'allow_client_ids': {'val': False, 'desc': 'Allow client to specify resource ids.'},
         'metadata_endpoints': {'val': True, 'desc': 'Should /metadata endpoint be enabled?'},
-        'metadata_modules': {'val': '', 'desc': 'Modules to load to provide metadata endpoints (defaults to all modules in the metadata package).'},
+        'metadata_modules': {'val': 'JSONSchema OpenAPI', 'desc': 'Modules to load to provide metadata endpoints (defaults are modules provided in the metadata package).'},
         'openapi_file': {'val': '', 'desc': 'File containing OpenAPI data (YAML or JSON)'},
         'paging_default_limit': {'val': 10, 'desc': 'Default pagination limit for collections.'},
         'paging_max_limit': {'val': 100, 'desc': 'Default limit on the number of items returned for collections.'},

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -3263,9 +3263,41 @@ class TestMetaData(DBTestBase):
         cls.api.create_jsonapi()
         cls.metadata = pyramid_jsonapi.metadata.MetaData(cls.api)
 
+    def test_no_jsonschema_module(self):
+        """Test how things break if jsonschema is disabled."""
+        self.test_app(
+            options={
+                'pyramid_jsonapi.metadata_modules': ''
+            }).post('/people', '{}', status=500)
+
+        self.test_app(
+            options={
+                'pyramid_jsonapi.metadata_modules': ''
+            }).get('/metadata/JSONSchema', '{}', status=404)
+
+    def test_disable_jsonschema_validation(self):
+        """Test disabling jsonschema and validation together works."""
+        self.test_app(
+            options={
+                'pyramid_jsonapi.metadata_modules': '',
+                'pyramid_jsonapi.schema_validation': 'false',
+            }).post_json(
+                '/people',
+                {
+                    'data': {
+                        'type': 'people',
+                        'attributes': {
+                            'name': 'test'
+                        }
+                    }
+                },
+                headers={'Content-Type': 'application/vnd.api+json'}
+            )
+
     def test_jsonschema_template(self):
-        """Test that template() returns valid json."""
-        json.dumps(self.metadata.JSONSchema.template())
+        """Test that template() returns valid json, and as a view."""
+        dir_tmpl = json.dumps(self.metadata.JSONSchema.template())
+        view_tmpl = self.test_app().get('/metadata/JSONSchema', '{}').json
 
     def test_jsonschema_load_schema_file(self):
         """Test loading jsonschema from file."""


### PR DESCRIPTION
* Use settings `metadata_modules` as definitive list.
* allows no modules to be loaded.
* Set default value to JSONSchema and OpenAPI
* Add tests to handle behaviour if modules not added.

(Also added unrelated pylint badge fix in this PR).