### PR TITLE
Add api_version configuration option

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -63,6 +63,7 @@ class PyramidJSONAPI():
     # Default configuration values
     config_defaults = {
         'allow_client_ids': {'val': False, 'desc': 'Allow client to specify resource ids.'},
+        'api_version': {'val': '', 'desc': 'API version for prefixing endpoints and metadata generation.'},
         'expose_foreign_keys': {'val': False, 'desc': 'Expose foreign key fields in JSON.'},
         'metadata_endpoints': {'val': True, 'desc': 'Should /metadata endpoint be enabled?'},
         'metadata_modules': {'val': 'JSONSchema OpenAPI', 'desc': 'Modules to load to provide metadata endpoints (defaults are modules provided in the metadata package).'},
@@ -111,7 +112,7 @@ class PyramidJSONAPI():
             ]
         }
 
-    def create_jsonapi(self, engine=None, test_data=None):
+    def create_jsonapi(self, engine=None, test_data=None, api_version=None):
         """Auto-create jsonapi from module or iterable of sqlAlchemy models.
 
         Keyword Args:
@@ -121,6 +122,7 @@ class PyramidJSONAPI():
                 the database.
         """
 
+        self.settings.api_version = api_version
         self.config.add_notfound_view(self.error, renderer='json')
         self.config.add_forbidden_view(self.error, renderer='json')
         self.config.add_view(self.error, context=HTTPError, renderer='json')

--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -176,7 +176,8 @@ class PyramidJSONAPI():
             self.create_resource(model_class)
 
         # Instantiate metadata now that view_class has been populated
-        self.metadata = pyramid_jsonapi.metadata.MetaData(self)
+        if self.settings.metadata_endpoints:
+            self.metadata = pyramid_jsonapi.metadata.MetaData(self)
 
     create_jsonapi_using_magic_and_pixie_dust = create_jsonapi  # pylint:disable=invalid-name
 

--- a/pyramid_jsonapi/endpoints.py
+++ b/pyramid_jsonapi/endpoints.py
@@ -21,6 +21,7 @@ class RoutePatternConstructor():
         self.sep = route_info['route_pattern_sep']
         self.pattern_prefix = route_info['route_pattern_prefix']
         self.api_prefix = route_info['api_prefix']
+        self.api_version = route_info['api_version']
         self.metadata_prefix = route_info['metadata_prefix']
 
     def pattern_from_components(self, *components):
@@ -50,7 +51,12 @@ class RoutePatternConstructor():
             *components (str): components to add after collection name.
         """
         pattern = self.pattern_from_components(
-            '', self.pattern_prefix, self.api_prefix, name, *components
+            '',
+            self.pattern_prefix,
+            self.api_version,
+            self.api_prefix,
+            name,
+            *components
         )
         if rstrip:
             pattern = pattern.rstrip(self.sep)
@@ -64,8 +70,12 @@ class RoutePatternConstructor():
             *components (str): components to add after metadata type.
         """
         return self.pattern_from_components(
-            '', self.pattern_prefix, self.metadata_prefix,
-            metadata_type, *components
+            '',
+            self.pattern_prefix,
+            self.api_version,
+            self.metadata_prefix,
+            metadata_type,
+            *components
         )
 
 
@@ -91,6 +101,7 @@ class EndpointData():
 
         if settings.metadata_endpoints:
             self.route_info['api_prefix'] = settings.route_pattern_api_prefix
+        self.route_info['api_version'] = settings.api_version
 
         self.rp_constructor = RoutePatternConstructor(self.route_info)
 

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -3212,6 +3212,59 @@ class TestJSONAPI(unittest.TestCase):
         self.assertTrue(len(doc.resources) == 2)
         self.assertEqual(doc._jsonapi['links'], links)
 
+
+class TestEndpoints(DBTestBase):
+    """Tests for endpoint configuration."""
+
+    def test_api_prefix(self):
+        """Test setting api prefix."""
+        self.test_app(
+            options={
+                'pyramid_jsonapi.route_pattern_api_prefix': 'api'
+            }).get('/api/people')
+
+    def test_metadata_endpoints_disable(self):
+        self.test_app(
+            options={
+                'pyramid_jsonapi.metadata_endpoints': 'false'
+            }).get('/metadata/JSONSchema', status=404)
+
+    def test_api_version(self):
+        """Test setting api version."""
+        self.test_app(
+            options={
+                'pyramid_jsonapi.api_version': '10'
+            }).get('/10/people')
+        self.test_app(
+            options={
+                'pyramid_jsonapi.api_version': '10'
+            }).get('/10/metadata/JSONSchema')
+
+    def test_route_pattern_prefix(self):
+        """Test setting route_pattern_prefix."""
+        self.test_app(
+            options={
+                'pyramid_jsonapi.route_pattern_prefix': 'SPLAT'
+            }).get('/SPLAT/people')
+        self.test_app(
+            options={
+                'pyramid_jsonapi.route_pattern_prefix': 'SPLAT'
+            }).get('/SPLAT/metadata/JSONSchema')
+
+    def test_route_pattern_api_prefix(self):
+        """Test setting route_pattern_api_prefix."""
+        self.test_app(
+            options={
+                'pyramid_jsonapi.route_pattern_api_prefix': 'API'
+            }).get('/API/people')
+
+    def test_route_pattern_ap_prefix(self):
+        """Test setting route_pattern_metadata_prefix."""
+        self.test_app(
+            options={
+                'pyramid_jsonapi.route_pattern_metadata_prefix': 'METADATA'
+            }).get('/METADATA/JSONSchema')
+
 class TestMetaData(DBTestBase):
     """Tests for the metadata plugins."""
 


### PR DESCRIPTION
If set, use in path construction (defaults to `''`).

Later PR will extend this to be the `version` value used in OpenAPI.