### PR TITLE
Refactor RoutePatternConstructor

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -112,7 +112,7 @@ class PyramidJSONAPI():
             ]
         }
 
-    def create_jsonapi(self, engine=None, test_data=None, api_version=None):
+    def create_jsonapi(self, engine=None, test_data=None, api_version=''):
         """Auto-create jsonapi from module or iterable of sqlAlchemy models.
 
         Keyword Args:
@@ -120,9 +120,12 @@ class PyramidJSONAPI():
                 debug view.
             test_data: a module with an ``add_to_db()`` method which will populate
                 the database.
+            api_version: An optional version to be used in generating urls, docs etc.
+                defaults to ''. Can also be set globally in settings ini file.
         """
 
-        self.settings.api_version = api_version
+        if api_version:
+            self.settings.api_version = api_version
         self.config.add_notfound_view(self.error, renderer='json')
         self.config.add_forbidden_view(self.error, renderer='json')
         self.config.add_view(self.error, context=HTTPError, renderer='json')

--- a/pyramid_jsonapi/endpoints.py
+++ b/pyramid_jsonapi/endpoints.py
@@ -34,8 +34,11 @@ class RoutePatternConstructor():
         Arguments:
             *components (str): route pattern components.
         """
-        components = [x.strip(self.settings.route_pattern_sep) for x in components if x != '']
-        return self.settings.route_pattern_sep.join(components)
+        components = [x for x in components if x != '']
+        return self.settings.route_pattern_sep.join(components).replace(
+            self.settings.route_pattern_sep * 2,
+            self.settings.route_pattern_sep
+        )
 
     def create_pattern(self, type_prefix, endpoint_name, *components, base='/', rstrip=True):
         """Generate a pattern from a type_prefix, endpoint name and suffix components.


### PR DESCRIPTION
Some steps to simplify the methods and their calling, and remove the legacy 'route_info' dict and use settings directly.