### PR TITLE
JSONSchema optimisations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 virtualenv:
   system_site_packages: true
 script:
-- pycodestyle --ignore=E501,E731 pyramid_jsonapi
+- pycodestyle --ignore=E402,E501,E731 pyramid_jsonapi
 - pylint -E --rcfile=.pylintrc pyramid_jsonapi
 - nosetest -v --with-coverage --cover-package=pyramid_jsonapi
 - travis_retry coveralls || true

--- a/pyramid_jsonapi/metadata/JSONSchema/__init__.py
+++ b/pyramid_jsonapi/metadata/JSONSchema/__init__.py
@@ -251,10 +251,6 @@ class JSONSchema():
             # Return reference to failure part of schema
             return {'$ref': '#/definitions/failure'}
 
-        # id is optional for POST
-        if method == 'post':
-            schema['definitions']['resource']['required'].remove('id')
-
         if direction == 'request':
             # Replace data with single (ep-specific) resource
             # (POST/PATCH can only be single resource)


### PR DESCRIPTION
It appeared that there were some inefficiencies in calling JSONSchema methods repeatedly (for example from the OpenAPI module) due to the use of `copy.deepcopy` to make modified copies of the schema dict for different endpoints.

The performance is good under python >= `3.6` but poor on `3.5` and below - `3.6` has had a lot of optimisations in both `dict` handling and `deepcopy`, not least moving many of these functions into dedicated C libraries.

The easiest 'fix' for this is to use `pickle` instead of `deepcopy`. Doing a `pickle.loads(pickle.dumps(x))` is fast as it all happens in C, and while it is not a universal equivalent to `deepcopy`, it is safe in this instance since the schema is JSON in origin so shouldn't contain any things which `pickle` might baulk at.

Performance in generating the OpenAPI specification in a test app (40 endpoints) is now approximately 12 times faster!