### PR TITLE
Error, notfound and forbidden views registered for more specific paths

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -187,10 +187,12 @@ class PyramidJSONAPI():
             prefnames.append('metadata')
         for prefname in prefnames:
             setting_name = 'route_pattern_{}_prefix'.format(prefname)
-            path_info = "/"
+            sep = self.settings.route_pattern_sep
             setting = getattr(self.settings, setting_name)
             if setting != '' and setting is not None:
-                path_info = path_info + setting + "/"
+                path_info = '{}{}{}'.format(sep, setting, sep)
+            else:
+                path_info = sep
             self.config.add_notfound_view(
                 self.error, renderer='json', path_info=path_info
             )

--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -126,9 +126,6 @@ class PyramidJSONAPI():
 
         if api_version:
             self.settings.api_version = api_version
-        self.config.add_notfound_view(self.error, renderer='json')
-        self.config.add_forbidden_view(self.error, renderer='json')
-        self.config.add_view(self.error, context=HTTPError, renderer='json')
 
         # Build a list of declarative models to add as collections.
         if isinstance(self.models, types.ModuleType):
@@ -183,6 +180,27 @@ class PyramidJSONAPI():
         # Instantiate metadata now that view_class has been populated
         if self.settings.metadata_endpoints:
             self.metadata = pyramid_jsonapi.metadata.MetaData(self)
+
+        # Add error views
+        prefnames = ['api']
+        if self.settings.metadata_endpoints:
+            prefnames.append('metadata')
+        for prefname in prefnames:
+            setting_name = 'route_pattern_{}_prefix'.format(prefname)
+            path_info = "/"
+            setting = getattr(self.settings, setting_name)
+            if setting != '' and setting is not None:
+                path_info = path_info + setting + "/"
+            self.config.add_notfound_view(
+                self.error, renderer='json', path_info=path_info
+            )
+            self.config.add_forbidden_view(
+                self.error, renderer='json', path_info=path_info
+            )
+            self.config.add_view(
+                self.error, context=HTTPError, renderer='json',
+                path_info=path_info
+            )
 
     create_jsonapi_using_magic_and_pixie_dust = create_jsonapi  # pylint:disable=invalid-name
 

--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -188,8 +188,8 @@ class PyramidJSONAPI():
         for prefname in prefnames:
             setting_name = 'route_pattern_{}_prefix'.format(prefname)
             sep = self.settings.route_pattern_sep
-            setting = getattr(self.settings, setting_name)
-            if setting != '' and setting is not None:
+            setting = str(getattr(self.settings, setting_name))
+            if setting != '':
                 path_info = '{}{}{}'.format(sep, setting, sep)
             else:
                 path_info = sep

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -2820,6 +2820,20 @@ class TestErrors(DBTestBase):
         self.assertIn('title', err)
         self.assertIn('detail', err)
 
+    def test_errors_only_controlled_paths(self):
+        '''Error handlers only for controlled paths ('api' and 'metadata')'''
+        app = self.test_app(
+            options={'pyramid_jsonapi.route_pattern_api_prefix': 'api'}
+        )
+        # Both /api/ and /metadata/ should have json structured errors
+        for path in ('/api/', '/metadata/'):
+            json = app.get(path, status=404).json
+        # Other paths should not have json errors
+        for path in ('/', '/splat/', '/api_extra/'):
+            r = app.get(path, status=404)
+            self.assertRaises(AttributeError, getattr, r, 'json')
+
+
     def test_errors_composite_key(self):
         '''Should raise exception if a model has a composite key.'''
         self.assertRaisesRegex(


### PR DESCRIPTION
These views now act only on paths that `pyramid_jsonapi` believes it controls - namely paths starting with `route_pattern_api_prefix` and `route_pattern_metadata_prefix` between slashes (or `/api/` and `/metadata/` by default).

fixes #151 