### PR TITLE
Use host_url as openapi api base url

### DIFF
--- a/pyramid_jsonapi/metadata/OpenAPI/__init__.py
+++ b/pyramid_jsonapi/metadata/OpenAPI/__init__.py
@@ -220,7 +220,7 @@ class OpenAPI():
             'contact': {
                 'name': self.metadata.author or '',
                 'email': self.metadata.author_email or '',
-                'url': self.metadata.home_page or ''
+                'url': self.metadata.home_page or request.host_url or ''
             },
             'license': {
                 'name': self.metadata.license or ''


### PR DESCRIPTION
If no `home_page` metadata value is specified, use the current base url that the OpenAPI docs are being served from as the API root in the specification.