### PR TITLE
Ignore errors about binary operator breaks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 virtualenv:
   system_site_packages: true
 script:
-- pycodestyle --ignore=E402,E501,E731 pyramid_jsonapi
+- pycodestyle --ignore=E402,E501,W503,W504,E731 pyramid_jsonapi
 - pylint -E --rcfile=.pylintrc pyramid_jsonapi
 - nosetest -v --with-coverage --cover-package=pyramid_jsonapi
 - travis_retry coveralls || true


### PR DESCRIPTION
From https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes:

* W503 (*)	line break before binary operator
* W504 (*)	line break after binary operator

(*) In the default configuration, the checks ... W503 and W504 ... are ignored because they are not rules unanimously accepted, and PEP 8 does not enforce them.

Not sure why they're now catching, so explicitly disable them.

Merging this PR should cause the other pending PRs to pass travis (I hope!)