### PR TITLE
Issue160

### DIFF
--- a/docs/source/customisation.rst
+++ b/docs/source/customisation.rst
@@ -66,6 +66,29 @@ Option            Value Type    Description
 visible           Boolean       Whether or not to display this colum in the API.
 ===============   ==========    ================================================
 
+Model Relationship Options
+--------------------------
+
+The same ``info`` attribute used to specify column options above can be used to
+specify relationship options. For example, to make a relationship called
+``invisible_comments`` invisible to the API:
+
+.. code-block:: python
+
+  class Person(Base):
+    __tablename__ = 'people'
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    invisible_comments = relationship('Comment')
+    invisible_comments.info.update({'pyramid_jsonapi': {'visible': False}})
+
+Available relationship options:
+
+===============   ==========    ================================================
+Option            Value Type    Description
+===============   ==========    ================================================
+visible           Boolean       Whether to display this relationship in the API.
+===============   ==========    ================================================
+
 Selectively Passing Models for API Generation
 ---------------------------------------------
 

--- a/pyramid_jsonapi/collection_view.py
+++ b/pyramid_jsonapi/collection_view.py
@@ -1708,7 +1708,7 @@ class CollectionViewBase:
                 is_included = True
             if key not in self.requested_relationships and not is_included:
                 continue
-            if self.mapped_info_from_name(key).get('visible', True) == False:
+            if not self.mapped_info_from_name(key).get('visible', True):
                 continue
             rel_dict = {
                 'data': None,

--- a/pyramid_jsonapi/collection_view.py
+++ b/pyramid_jsonapi/collection_view.py
@@ -1633,11 +1633,11 @@ class CollectionViewBase:
             item = False
         return bool(item)
 
-    def column_info_from_name(self, name, model=None):
-        """Get the pyramid_jsonapi info dictionary for a column.
+    def mapped_info_from_name(self, name, model=None):
+        """Get the pyramid_jsonapi info dictionary for a mapped object.
 
         Parameters:
-            name (str): name of column.
+            name (str): name of object.
 
             model (sqlalchemy.ext.declarative.declarative_base): model to
                 inspect. Defaults to self.model.
@@ -1697,7 +1697,7 @@ class CollectionViewBase:
         resource_json.attributes = {
             key: getattr(item, key)
             for key in self.requested_attributes.keys()
-            if self.column_info_from_name(key).get('visible', True)
+            if self.mapped_info_from_name(key).get('visible', True)
         }
         resource_json.links = {'self': item_url}
 
@@ -1707,6 +1707,8 @@ class CollectionViewBase:
             if '.'.join(include_path + [key]) in self.requested_include_names():
                 is_included = True
             if key not in self.requested_relationships and not is_included:
+                continue
+            if self.mapped_info_from_name(key).get('visible', True) == False:
                 continue
             rel_dict = {
                 'data': None,

--- a/test_project/test_project/models.py
+++ b/test_project/test_project/models.py
@@ -51,6 +51,7 @@ class Person(Base):
     blogs = relationship('Blog', backref='owner')
     posts = relationship('Post', backref='author')
     comments = relationship('Comment', backref='author')
+    invisible_comments = relationship('Comment')
     articles_by_assoc = relationship(
         "ArticleByAssoc",
         secondary=authors_articles_assoc,

--- a/test_project/test_project/models.py
+++ b/test_project/test_project/models.py
@@ -68,6 +68,7 @@ class Person(Base):
     # make invisible columns invisible to API
     invisible.info.update({'pyramid_jsonapi': {'visible': False}})
     invisible_hybrid.info.update({'pyramid_jsonapi': {'visible': False}})
+    invisible_comments.info.update({'pyramid_jsonapi': {'visible': False}})
 
 class Blog(Base):
     __tablename__ = 'blogs'

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -3006,6 +3006,13 @@ class TestFeatures(DBTestBase):
         self.assertNotIn('invisible', atts)
         self.assertNotIn('invisible_hybrid', atts)
 
+    def test_feature_invisible_relationship(self):
+        '''people object should not have relationship "invisible_comments".'''
+        rels = self.test_app().get(
+            '/people/1'
+        ).json['data']['relationships']
+        self.assertNotIn('invisible_comments', rels)
+
     def test_feature_rename_collection(self):
         '''Should be able to fetch from whatsits even though table is things.'''
         # There should be whatsits...


### PR DESCRIPTION
Allow relationships' visibility to be controlled via an option specified in the model. Fixes #160.

A helper function has changed name from `column_info_from_name` to `mapper_info_from_name` to reflect its more general use.