### PR TITLE
View construction fixes

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -188,13 +188,12 @@ class PyramidJSONAPI():
         if self.settings.metadata_endpoints:
             prefnames.append('metadata')
         for prefname in prefnames:
-            setting_name = 'route_pattern_{}_prefix'.format(prefname)
-            sep = self.settings.route_pattern_sep
-            setting = str(getattr(self.settings, setting_name))
-            if setting != '':
-                path_info = '{}{}{}'.format(sep, setting, sep)
-            else:
-                path_info = sep
+            path_info = self.endpoint_data.rp_constructor.pattern_from_components(
+                str(getattr(self.settings, 'route_pattern_prefix')),
+                str(getattr(self.settings, 'route_pattern_{}_prefix'.format(prefname))),
+                start_sep=True,
+                end_sep=True
+            )
             self.config.add_notfound_view(
                 self.error, renderer='json', path_info=path_info
             )

--- a/pyramid_jsonapi/endpoints.py
+++ b/pyramid_jsonapi/endpoints.py
@@ -25,7 +25,7 @@ class RoutePatternConstructor():
         self.api_pattern = partial(self.create_pattern, self.settings.route_pattern_api_prefix)
         self.metadata_pattern = partial(self.create_pattern, self.settings.route_pattern_metadata_prefix)
 
-    def pattern_from_components(self, *components):
+    def pattern_from_components(self, *components, start_sep=False, end_sep=False):
         """Construct a route pattern from components.
 
         Join components together with self.sep.
@@ -33,12 +33,17 @@ class RoutePatternConstructor():
 
         Arguments:
             *components (str): route pattern components.
+            start_sep (bool): Add a leading separator
+            end_sep (bool): Add a trailing separator
         """
+        psep = self.settings.route_pattern_sep
         components = [x for x in components if x != '']
-        return self.settings.route_pattern_sep.join(components).replace(
-            self.settings.route_pattern_sep * 2,
-            self.settings.route_pattern_sep
-        )
+        pattern = psep.join(components).replace(psep * 2, psep)
+        if start_sep and not pattern.startswith(psep):
+            pattern = '{}{}'.format(psep, pattern)
+        if end_sep and not pattern.endswith(psep):
+            pattern = '{}{}'.format(pattern, psep)
+        return pattern
 
     def create_pattern(self, type_prefix, endpoint_name, *components, base='/', rstrip=True):
         """Generate a pattern from a type_prefix, endpoint name and suffix components.

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -22,8 +22,6 @@ import pyramid_jsonapi.jsonapi
 import pyramid_jsonapi.metadata
 from openapi_spec_validator import validate_spec
 
-from pprint import pprint
-
 from test_project.models import (
     DBSession,
     Base
@@ -397,7 +395,6 @@ class TestRelationships(DBTestBase):
             items = json['data']
             # For each returned item, there should be at least one related
             # item which matches the filter.
-            print([item['attributes'][filter.att] for item in included.values()])
             for item in items:
                 res_ids = item['relationships'][src.rel]['data']
                 self.assertIsNotNone(res_ids)
@@ -2658,7 +2655,6 @@ class TestBugs(DBTestBase):
         '''Should treat association proxy as a relationship.'''
         data = self.test_app().get('/people/1').json['data']
         self.assertIn('articles_by_proxy', data['relationships'])
-        print(data['relationships']['articles_by_proxy'])
 
 
 class TestJSONAPI(unittest.TestCase):

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -2791,6 +2791,15 @@ class TestEndpoints(DBTestBase):
                 'pyramid_jsonapi.route_pattern_prefix': 'SPLAT'
             }).get('/SPLAT/metadata/JSONSchema')
 
+    def test_route_pattern_prefix_error(self):
+        """Test setting route_pattern_prefix error handling."""
+        resp = self.test_app(
+            options={
+                'pyramid_jsonapi.route_pattern_prefix': 'SPLAT'
+            }).get('/SPLAT/invalid',
+            status=404)
+        self.assertTrue(resp.content_type == 'application/vnd.api+json')
+
     def test_route_pattern_api_prefix(self):
         """Test setting route_pattern_api_prefix."""
         self.test_app(
@@ -2798,12 +2807,59 @@ class TestEndpoints(DBTestBase):
                 'pyramid_jsonapi.route_pattern_api_prefix': 'API'
             }).get('/API/people')
 
-    def test_route_pattern_ap_prefix(self):
+    def test_route_pattern_api_prefix_error(self):
+        """Test setting route_pattern_prefix error handling."""
+        resp = self.test_app(
+            options={
+                'pyramid_jsonapi.route_pattern_api_prefix': 'API'
+            }).get('/API/invalid',
+            status=404)
+        self.assertTrue(resp.content_type == 'application/vnd.api+json')
+
+    def test_route_pattern_metadata_prefix(self):
         """Test setting route_pattern_metadata_prefix."""
         self.test_app(
             options={
                 'pyramid_jsonapi.route_pattern_metadata_prefix': 'METADATA'
             }).get('/METADATA/JSONSchema')
+
+    def test_route_pattern_metadata_prefix_error(self):
+        """Test setting route_pattern_prefix error handling."""
+        resp = self.test_app(
+            options={
+                'pyramid_jsonapi.route_pattern_metadata_prefix': 'METADATA'
+            }).get('/METADATA/invalid',
+            status=404)
+        self.assertTrue(resp.content_type == 'application/vnd.api+json')
+
+    def test_route_pattern_all_prefixes(self):
+        """Test setting all pattern prefixes."""
+        api = self.test_app(
+            options={
+                'pyramid_jsonapi.route_pattern_prefix': 'SPLAT',
+                'pyramid_jsonapi.route_pattern_api_prefix': 'API',
+                'pyramid_jsonapi.route_pattern_metadata_prefix': 'METADATA'
+            })
+        api.get('/SPLAT/API/people')
+        api.get('/SPLAT/METADATA/JSONSchema')
+
+    def test_route_pattern_all_prefixes_error(self):
+        """Test setting all pattern prefixes error handling."""
+        api = self.test_app(
+            options={
+                'pyramid_jsonapi.route_pattern_prefix': 'SPLAT',
+                'pyramid_jsonapi.route_pattern_api_prefix': 'API',
+                'pyramid_jsonapi.route_pattern_metadata_prefix': 'METADATA'
+            })
+        self.assertEqual(
+            api.get('/SPLAT/API/invalid', status=404).content_type,
+            'application/vnd.api+json'
+        )
+        self.assertEqual(
+            api.get('/SPLAT/METADATA/invalid', status=404).content_type,
+            'application/vnd.api+json'
+        )
+
 
 class TestMetaData(DBTestBase):
     """Tests for the metadata plugins."""

--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,8 @@ commands=
     pip install -e test_project
     pylint --errors-only --rcfile=.pylintrc pyramid_jsonapi
     pycodestyle --ignore=E402,E501,W503,W504,E731 pyramid_jsonapi
-    # Call unittest from coverage
-    coverage run --source=pyramid_jsonapi -m unittest discover test_project
+    # Call unittest from coverage (add --buffer to 'discover' to hide output from tests that pass)
+    coverage run --source=pyramid_jsonapi -m unittest discover --verbose test_project
     # Generate coverage report
     coverage report -m
     # Try to push coverage data to coveralls (ignore exit code as will fail if not on travis)


### PR DESCRIPTION
Tidy up the creation of views:

- Use `route_pattern_prefix` in view path if specified.
- Use the (modified) `pattern_from_components` method (shorter and DRYer).
- Add tests for the various prefixes, and their error states.
- Misc test tidying and tox fixes.