### PR TITLE
Add api_version to view construction

### DIFF
--- a/docs/source/customisation.rst
+++ b/docs/source/customisation.rst
@@ -98,6 +98,23 @@ Your database may have some tables which you do not wish to expose as collection
 * passing an iterable of only the model classes you wish to expose to
   :func:`pyramid_jsonapi.PyramidJSONAPI`.
 
+URL Paths
+---------
+
+There are a number of `prefix` configuration options that can be used to customise the URL path used in the generated API.
+These are useful for mixing the API with other pages, adding API versioning etc.
+
+The path is constructed as follows - omitting any variables which are unset.
+The separator between fields is `route_pattern_sep` - shown here as the default '/'.
+`type` is one of either `api` or `metadata`.
+
+```
+/route_pattern_prefix/api_version/route_pattern_<type>_prefix/endpoint
+```
+
+These options and their defaults are documented above in `Configuration Options`.
+
+
 Modifying Endpoints
 -------------------
 

--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -190,6 +190,7 @@ class PyramidJSONAPI():
         for prefname in prefnames:
             path_info = self.endpoint_data.rp_constructor.pattern_from_components(
                 str(getattr(self.settings, 'route_pattern_prefix')),
+                str(getattr(self.settings, 'api_version')),
                 str(getattr(self.settings, 'route_pattern_{}_prefix'.format(prefname))),
                 start_sep=True,
                 end_sep=True

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -2796,6 +2796,22 @@ class TestEndpoints(DBTestBase):
             status=404)
         self.assertTrue(resp.content_type == 'application/vnd.api+json')
 
+    def test_api_version(self):
+        """Test setting api_version."""
+        self.test_app(
+            options={
+                'pyramid_jsonapi.api_version': 'v1',
+            }).get('/v1/people')
+
+    def test_api_version_error(self):
+        """Test setting api_version error handling."""
+        resp = self.test_app(
+            options={
+                'pyramid_jsonapi.api_version': 'v1',
+            }).get('/v1/invalid',
+            status=404)
+        self.assertTrue(resp.content_type == 'application/vnd.api+json')
+
     def test_route_pattern_api_prefix(self):
         """Test setting route_pattern_api_prefix."""
         self.test_app(
@@ -2833,26 +2849,28 @@ class TestEndpoints(DBTestBase):
         api = self.test_app(
             options={
                 'pyramid_jsonapi.route_pattern_prefix': 'SPLAT',
+                'pyramid_jsonapi.api_version': 'v1',
                 'pyramid_jsonapi.route_pattern_api_prefix': 'API',
                 'pyramid_jsonapi.route_pattern_metadata_prefix': 'METADATA'
             })
-        api.get('/SPLAT/API/people')
-        api.get('/SPLAT/METADATA/JSONSchema')
+        api.get('/SPLAT/v1/API/people')
+        api.get('/SPLAT/v1/METADATA/JSONSchema')
 
     def test_route_pattern_all_prefixes_error(self):
         """Test setting all pattern prefixes error handling."""
         api = self.test_app(
             options={
                 'pyramid_jsonapi.route_pattern_prefix': 'SPLAT',
+                'pyramid_jsonapi.api_version': 'v1',
                 'pyramid_jsonapi.route_pattern_api_prefix': 'API',
                 'pyramid_jsonapi.route_pattern_metadata_prefix': 'METADATA'
             })
         self.assertEqual(
-            api.get('/SPLAT/API/invalid', status=404).content_type,
+            api.get('/SPLAT/v1/API/invalid', status=404).content_type,
             'application/vnd.api+json'
         )
         self.assertEqual(
-            api.get('/SPLAT/METADATA/invalid', status=404).content_type,
+            api.get('/SPLAT/v1/METADATA/invalid', status=404).content_type,
             'application/vnd.api+json'
         )
 


### PR DESCRIPTION
The same issue as fixed in the previous PR, but for `api_version`.

Also added documentation for `URL Paths` to explain how the prefixes get combined.

*Note*: We'll need a tag added to `master` once this is merged to get the docs updated and a new release with these fixes in.