### PR TITLE
Fix adjacancy

### DIFF
--- a/pyramid_jsonapi/collection_view.py
+++ b/pyramid_jsonapi/collection_view.py
@@ -120,11 +120,12 @@ class CollectionViewBase:
                         if hasattr(exc, 'code'):
                             try:
                                 # We have a code but it's probably a string. We need an integer.
-                                int_code = int(exc.code)
-                            except:
+                                int_code = int(exc.code)  # pylint: disable=no-member
+                            except Exception as ex2:
                                 # If we can't turn it into an integer then we're really stuck.
-                                raise HTTPInternalServerError("Unexpected server error.")
-                            if 400 <= int(exc.code) < 500:  # pylint:disable=no-member
+                                # raise HTTPInternalServerError("Unexpected server error.")
+                                int_code = 500
+                            if 400 <= int_code < 500:  # pylint:disable=no-member
                                 raise HTTPBadRequest("Unexpected client error: {}".format(exc))
                         else:
                             raise HTTPInternalServerError("Unexpected server error.")

--- a/test_project/development.ini
+++ b/test_project/development.ini
@@ -40,7 +40,7 @@ pyramid_jsonapi.allow_client_ids = true
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0
-port = 6543
+port = 6544
 
 ###
 # logging configuration

--- a/test_project/test_project/models.py
+++ b/test_project/test_project/models.py
@@ -224,3 +224,13 @@ class RenamedThings(Base):
     __pyramid_jsonapi__ = {
         'collection_name': 'whatsits'
     }
+
+
+class TreeNode(Base):
+    __tablename__ = 'treenodes'
+    id = IdColumn()
+    name = Column(Text)
+    parent_id = IdRefColumn('treenodes.id')
+    children = relationship("TreeNode",
+        backref=backref('parent', remote_side=[id])
+    )

--- a/test_project/test_project/test_data.json
+++ b/test_project/test_project/test_data.json
@@ -484,22 +484,22 @@
         },
         {
           "id": "2",
-          "name": "top.1",
+          "name": "top_1",
           "parent_id": "1"
         },
         {
           "id": "3",
-          "name": "top.2",
+          "name": "top_2",
           "parent_id": "1"
         },
         {
           "id": "4",
-          "name": "top.1.1",
+          "name": "top_1_1",
           "parent_id": "2"
         },
         {
           "id": "5",
-          "name": "top.1.2",
+          "name": "top_1_2",
           "parent_id": "2"
         }
       ],

--- a/test_project/test_project/test_data.json
+++ b/test_project/test_project/test_data.json
@@ -473,6 +473,37 @@
         }
       ],
       {"id_seq": "*"}
+    ],
+    [
+      "TreeNode",
+      [
+        {
+          "id": "1",
+          "name": "top",
+          "parent_id": null
+        },
+        {
+          "id": "2",
+          "name": "top.1",
+          "parent_id": "1"
+        },
+        {
+          "id": "3",
+          "name": "top.2",
+          "parent_id": "1"
+        },
+        {
+          "id": "4",
+          "name": "top.1.1",
+          "parent_id": "2"
+        },
+        {
+          "id": "5",
+          "name": "top.1.2",
+          "parent_id": "2"
+        }
+      ],
+      {"id_seq": "*"}
     ]
   ],
   "associations": [

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -159,21 +159,7 @@ class DBTestBase(unittest.TestCase):
 
 class TestTmp(DBTestBase):
     '''To isolate tests so they can be run individually during development.'''
-    def test_adjacancy_list(self):
-        top = self.test_app().get('/treenodes/1').json
-        top_1 = self.test_app().get('/treenodes/2').json
-        # top should have no parent.
-        self.assertIsNone(top['data']['relationships']['parent']['data'])
-        # top should have multiple children.
-        self.assertIsInstance(top['data']['relationships']['children']['data'], list)
-        # top_1 should have top as a parent.
-        self.assertEqual(
-            top_1['data']['relationships']['parent']['data'],
-            {'type': 'treenodes', 'id': '1'}
-        )
-        # top_1 should have 2 children.
-        self.assertIsInstance(top_1['data']['relationships']['children']['data'], list)
-        self.assertEqual(len(top_1['data']['relationships']['children']['data']), 2)
+
 
 class TestRelationships(DBTestBase):
     '''Test functioning of relationsips.
@@ -1137,6 +1123,24 @@ class TestRelationships(DBTestBase):
             headers={'Content-Type': 'application/vnd.api+json'},
             status=400
         )
+
+    def test_adjacancy_list(self):
+        '''Should correctly identify parent and children for TreeNode.
+        '''
+        top = self.test_app().get('/treenodes/1').json
+        top_1 = self.test_app().get('/treenodes/2').json
+        # top should have no parent.
+        self.assertIsNone(top['data']['relationships']['parent']['data'])
+        # top should have multiple children.
+        self.assertIsInstance(top['data']['relationships']['children']['data'], list)
+        # top_1 should have top as a parent.
+        self.assertEqual(
+            top_1['data']['relationships']['parent']['data'],
+            {'type': 'treenodes', 'id': '1'}
+        )
+        # top_1 should have 2 children.
+        self.assertIsInstance(top_1['data']['relationships']['children']['data'], list)
+        self.assertEqual(len(top_1['data']['relationships']['children']['data']), 2)
 
 
 class TestSpec(DBTestBase):

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -162,9 +162,6 @@ class TestTmp(DBTestBase):
     def test_adjacancy_list(self):
         top = self.test_app().get('/treenodes/1').json
         top_1 = self.test_app().get('/treenodes/2').json
-        # import pprint
-        # pprint.pprint(top['data']['relationships'])
-        # pprint.pprint(top_1['data']['relationships'])
         # top should have no parent.
         self.assertIsNone(top['data']['relationships']['parent']['data'])
         # top should have multiple children.
@@ -172,7 +169,7 @@ class TestTmp(DBTestBase):
         # top_1 should have top as a parent.
         self.assertEqual(
             top_1['data']['relationships']['parent']['data'],
-            {'type': 'treenodes', 'id': '4'}
+            {'type': 'treenodes', 'id': '1'}
         )
         # top_1 should have 2 children.
         self.assertIsInstance(top_1['data']['relationships']['children']['data'], list)

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -159,6 +159,24 @@ class DBTestBase(unittest.TestCase):
 
 class TestTmp(DBTestBase):
     '''To isolate tests so they can be run individually during development.'''
+    def test_adjacancy_list(self):
+        top = self.test_app().get('/treenodes/1').json
+        top_1 = self.test_app().get('/treenodes/2').json
+        # import pprint
+        # pprint.pprint(top['data']['relationships'])
+        # pprint.pprint(top_1['data']['relationships'])
+        # top should have no parent.
+        self.assertIsNone(top['data']['relationships']['parent']['data'])
+        # top should have multiple children.
+        self.assertIsInstance(top['data']['relationships']['children']['data'], list)
+        # top_1 should have top as a parent.
+        self.assertEqual(
+            top_1['data']['relationships']['parent']['data'],
+            {'type': 'treenodes', 'id': '4'}
+        )
+        # top_1 should have 2 children.
+        self.assertIsInstance(top_1['data']['relationships']['children']['data'], list)
+        self.assertEqual(len(top_1['data']['relationships']['children']['data']), 2)
 
 class TestRelationships(DBTestBase):
     '''Test functioning of relationsips.


### PR DESCRIPTION
Fixes a problem where tables with relationships back to themselves would not work in one direction. For example, for a TreeNode realised with the adjacency list pattern, the relationship 'parent' would always return null.