### PR TITLE
Refactor to allow setting id_col_name in model

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -238,24 +238,24 @@ class PyramidJSONAPI():
                 ``collection_view_factory()``
         """
 
-        # Find the primary key column from the model and use as 'id_col_name'
-        try:
-            keycols = sqlalchemy.inspect(model).primary_key
-        except sqlalchemy.exc.NoInspectionAvailable:
-            # Trying to inspect the declarative_base() raises this exception. We
-            # don't want to add it to the API.
-            return
-        # Only deal with one primary key column.
-        if len(keycols) > 1:
-            raise Exception(
-                'Model {} has more than one primary key.'.format(
-                    model.__name__
-                )
-            )
-
         if not hasattr(model, '__pyramid_jsonapi__'):
             model.__pyramid_jsonapi__ = {}
+
         if 'id_col_name' not in model.__pyramid_jsonapi__:
+            # Find the primary key column from the model and use as 'id_col_name'
+            try:
+                keycols = sqlalchemy.inspect(model).primary_key
+            except sqlalchemy.exc.NoInspectionAvailable:
+                # Trying to inspect the declarative_base() raises this exception.
+                # We don't want to add it to the API.
+                return
+            # Only deal with one primary key column.
+            if len(keycols) > 1:
+                raise Exception(
+                    'Model {} has more than one primary key.'.format(
+                        model.__name__
+                    )
+                )
             model.__pyramid_jsonapi__['id_col_name'] = keycols[0].name
 
         # Create a view class for use in the various add_view() calls below.


### PR DESCRIPTION
Allows primary key to be defined by doing e.g.:

`__pyramid_jsonapi__['id_col_name'] = 'col_name'`

There's no documentation included in this just yet - let me know if I should update the docs, or if you just want to make a note to do this in the 2_2 docs overhaul.