### PR TITLE
Fix ltree_models in test_project.

### DIFF
--- a/test_project/setup.py
+++ b/test_project/setup.py
@@ -8,18 +8,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.txt')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
 
-
-def local_ltree_pkg():
-    list_of_files = glob.glob('/home/chiggs1/git/ltree_models/dist/*.tar.gz')
-    return max(list_of_files, key=os.path.getctime)
-
-def ltree_version(path):
-    fname = os.path.basename(path)
-    match = re.search(r'ltree_models-(.*)\.tar\.gz', fname)
-    return match.group(1)
-
 requires = [
-    # f'ltree @ file://localhost{local_ltree_pkg()}',
     'ltree_models',
     'openapi_spec_validator',
     'psycopg2',

--- a/test_project/test_project/test_data.py
+++ b/test_project/test_project/test_data.py
@@ -15,7 +15,7 @@ import json
 from pathlib import Path
 import re
 
-import ltree
+import ltree_models as ltree
 
 def add_to_db(engine):
     '''Add some basic test data.'''

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -21,7 +21,7 @@ from parameterized import parameterized
 import pyramid_jsonapi.metadata
 from openapi_spec_validator import validate_spec
 import pprint
-import ltree
+import ltree_models as ltree
 from pyramid_jsonapi.permissions import (
     Permission,
     Targets,


### PR DESCRIPTION
Some fixes to get tox testing working again.

Note there is also a `pylint` error, which requires knowledge of the code to fix:

```
pyramid_jsonapi/permissions.py:95:43: E1101: Instance of 'PermissionBase' has no 'id' member (no-member)
```

(There are also some selling errors in method names etc in permissions, though that's less important!)

Once this is merged and pylint made happy I can look at re-enabling CI with github actions.
