### PR TITLE
docs: Fix a few typos

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -118,7 +118,7 @@ Permissions required:
 
   1. `POST` for the supplied resource. `pfilter` return of `True` will allow the whole resource through; dictionary will strip any blocked attributes and rels before attempting to create the resource (which might result in failure); `False` will entirely block creation (HTTPForbidden).
   2. `POST` for the relationship for any supplied relationships.
-  3. `POST` (if the the created resource will be added to a `to_many` relationship of the related resource) or `PATCH` (if the created resrouce will be the target of a `to_one` relationship of the related resource) for the reverse relationship of any resources in supplied relationships?
+  3. `POST` (if the the created resource will be added to a `to_many` relationship of the related resource) or `PATCH` (if the created resource will be the target of a `to_one` relationship of the related resource) for the reverse relationship of any resources in supplied relationships?
 
 Illustrating creating a resource with supplied relationsips:
 

--- a/pyramid_jsonapi/collection_view.py
+++ b/pyramid_jsonapi/collection_view.py
@@ -718,7 +718,7 @@ class CollectionViewBase:
         """Add sorting to query.
 
         Use information from the ``sort`` query parameter (via
-        :py:func:`collection_query_info`) to contruct an ``order_by`` clause on
+        :py:func:`collection_query_info`) to construct an ``order_by`` clause on
         the query.
 
         See Also:

--- a/pyramid_jsonapi/metadata/JSONSchema/__init__.py
+++ b/pyramid_jsonapi/metadata/JSONSchema/__init__.py
@@ -219,7 +219,7 @@ class JSONSchema():
         Raises:
             HTTPNotFound error for unknown endpoints.
 
-        Takes 1 path parameert:
+        Takes 1 path parameter:
           * 'endpoint'
 
         Takes 3 optional query parameters:

--- a/pyramid_jsonapi/metadata/OpenAPI/__init__.py
+++ b/pyramid_jsonapi/metadata/OpenAPI/__init__.py
@@ -85,7 +85,7 @@ class OpenAPI():
 
     @functools.lru_cache()
     def generate_pkg_metadata(self):
-        """Get metadatsa for 'parent' pyramid package."""
+        """Get metadata for 'parent' pyramid package."""
         # Get the PKG-INFO metadata for the 'parent' pyramid app
         pkg_name = self.api.config.package_name
         self.metadata = pkginfo.Installed(pkg_name)
@@ -104,7 +104,7 @@ class OpenAPI():
         }
 
     def build_parameters(self, opts):
-        """Build paramaters schema."""
+        """Build parameters schema."""
 
         # Add 'in: query' parameters - 'global' and ep-specific
         parameters = []


### PR DESCRIPTION
There are small typos in:
- notes.md
- pyramid_jsonapi/collection_view.py
- pyramid_jsonapi/metadata/JSONSchema/__init__.py
- pyramid_jsonapi/metadata/OpenAPI/__init__.py

Fixes:
- Should read `resource` rather than `resrouce`.
- Should read `parameters` rather than `paramaters`.
- Should read `parameter` rather than `parameert`.
- Should read `construct` rather than `contruct`.
- Should read `metadata` rather than `metadatsa`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md